### PR TITLE
bugfix: insert data first, update id should be after data inserted

### DIFF
--- a/item-service/src/main/java/com/airmart/itemservice/itemquery/service/Implement/ItemQueryServiceImpl.java
+++ b/item-service/src/main/java/com/airmart/itemservice/itemquery/service/Implement/ItemQueryServiceImpl.java
@@ -25,13 +25,16 @@ public class ItemQueryServiceImpl implements ItemQueryService {
     private final ItemQueryRepository itemQueryRepository;
     private final SequenceGeneratorService sequenceGeneratorService;
     private final ItemQueryMapper itemQueryMapper;
+    private static long closingItemSeq = 0L;
 
     @Override
     public ItemQueryDTO.Response getClosingItemList() {
         ClosingItemList closingItemList = itemQueryRepository
-                .findById(sequenceGeneratorService
-                        .getCurrentSequence(ClosingItemList.SEQUENCE_NAME))
-                .orElseThrow(() -> BusinessException.create(BusinessExceptionDictionary.UNKNOWN));
+                .findById(closingItemSeq)
+                .orElseThrow(() -> {
+                    log.error("Closing Item List Seq: " + closingItemSeq);
+                    return BusinessException.create(BusinessExceptionDictionary.UNKNOWN);
+                });
         return ItemQueryDTO.Response.builder()
                 .itemList(closingItemList.getClosingItemList())
                 .build();
@@ -46,5 +49,6 @@ public class ItemQueryServiceImpl implements ItemQueryService {
                         .collect(Collectors.toList()))
                 .build();
         itemQueryRepository.save(closingItemList);
+        closingItemSeq = closingItemList.getId();
     }
 }


### PR DESCRIPTION
* 중간 커밋을 남기지 않아서 버그였던 상황이 남아있지 않아 설명으로 대체
  * ID를 계속 DB에서 조회하는 비효율적인 상황을 개선하고자 static 변수로 최신 ID를 저장하도록 수정
  * 최신 ID를 최신 배치 데이터를 db에 삽입 전에 static 변수를 업데이트함
  * API Request가 DB insert 직전에 오면 최신 ID의 데이터는 없는 상태여서 API fail
  * 해당 논리상 잘못된 순서 수정하여 ID를 나중에 update